### PR TITLE
feat: add socket.io and websocket support to the project-group chat

### DIFF
--- a/apps/api-gateway/src/api-gateway.module.ts
+++ b/apps/api-gateway/src/api-gateway.module.ts
@@ -5,8 +5,11 @@ import { ClientsModule, Transport } from '@nestjs/microservices';
 import { AuthGatewayController } from './auth/authGateway.controller';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtAuthGuard } from './jwt-auth.guard';
+import { WsJwtAuthGuard } from './ws-jwt-auth.guard';
 import { NotificationGatewayController } from './notification/notificationGateway.controller';
 import { WorkspaceGatewayController } from './workspace/workspaceGateway.controller';
+import { ChatGateway } from './chat/chat.gateway';
+import { ChatController } from './chat/chat.controller';
 
 @Module({
   imports: [
@@ -41,8 +44,8 @@ import { WorkspaceGatewayController } from './workspace/workspaceGateway.control
       }
     ]),
   ],
-  controllers: [ApiGatewayController, AuthGatewayController, NotificationGatewayController, WorkspaceGatewayController],
-  providers: [ApiGatewayService, JwtAuthGuard],
+  controllers: [ApiGatewayController, AuthGatewayController, NotificationGatewayController, WorkspaceGatewayController, ChatController],
+  providers: [ApiGatewayService, JwtAuthGuard, WsJwtAuthGuard, ChatGateway],
   exports: [JwtAuthGuard],
 })
 export class ApiGatewayModule {}

--- a/apps/api-gateway/src/chat/chat.controller.ts
+++ b/apps/api-gateway/src/chat/chat.controller.ts
@@ -1,0 +1,106 @@
+import { Controller, Get, Post, Body, Param, Query, UseGuards, Request } from '@nestjs/common';
+import { Inject } from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
+import { JwtAuthGuard } from '../jwt-auth.guard';
+import { firstValueFrom } from 'rxjs';
+
+@Controller('chat')
+@UseGuards(JwtAuthGuard)
+export class ChatController {
+  constructor(
+    @Inject('workspace-group-service') private workspaceService: ClientProxy,
+  ) {}
+
+  @Get('history/:groupId')
+  async getChatHistory(
+    @Param('groupId') groupId: string,
+    @Query('limit') limit: string = '50',
+    @Query('offset') offset: string = '0',
+    @Request() req: any
+  ) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      
+      const chatHistory = await firstValueFrom(
+        this.workspaceService.send('get_chat_history', {
+          userId,
+          getChatHistoryDto: {
+            groupId,
+            limit: parseInt(limit),
+            offset: parseInt(offset)
+          }
+        })
+      );
+
+      return {
+        success: true,
+        data: chatHistory
+      };
+    } catch (error) {
+      console.error('Error getting chat history:', error);
+      return {
+        success: false,
+        message: 'Failed to get chat history',
+        error: error.message
+      };
+    }
+  }
+
+  @Post('send')
+  async sendMessage(
+    @Body() body: { groupId: string; text: string },
+    @Request() req: any
+  ) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      
+      const savedMessage = await firstValueFrom(
+        this.workspaceService.send('send_chat_message', {
+          userId,
+          sendChatMessageDto: {
+            groupId: body.groupId,
+            text: body.text
+          }
+        })
+      );
+
+      return {
+        success: true,
+        data: savedMessage
+      };
+    } catch (error) {
+      console.error('Error sending message:', error);
+      return {
+        success: false,
+        message: 'Failed to send message',
+        error: error.message
+      };
+    }
+  }
+
+  @Get('group/:groupId/members')
+  async getGroupMembers(
+    @Param('groupId') groupId: string,
+    @Request() req: any
+  ) {
+    try {
+      const members = await firstValueFrom(
+        this.workspaceService.send('get_group_members', {
+          groupId
+        })
+      );
+
+      return {
+        success: true,
+        data: members
+      };
+    } catch (error) {
+      console.error('Error getting group members:', error);
+      return {
+        success: false,
+        message: 'Failed to get group members',
+        error: error.message
+      };
+    }
+  }
+}

--- a/apps/api-gateway/src/chat/chat.gateway.ts
+++ b/apps/api-gateway/src/chat/chat.gateway.ts
@@ -1,0 +1,250 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  ConnectedSocket,
+  MessageBody,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { Injectable, UseGuards, Inject } from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
+import { JwtService } from '@nestjs/jwt';
+import { firstValueFrom } from 'rxjs';
+import { WsJwtAuthGuard } from '../ws-jwt-auth.guard';
+import type { AuthenticatedSocket } from '../ws-jwt-auth.guard';
+
+@Injectable()
+@WebSocketGateway({
+  cors: {
+    origin: "*",
+    methods: ["GET", "POST"]
+  },
+  namespace: '/chat'
+})
+export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server: Server;
+
+  private connectedUsers = new Map<string, AuthenticatedSocket>();
+
+  constructor(
+    @Inject('workspace-group-service') private workspaceService: ClientProxy,
+    private jwtService: JwtService,
+  ) {}
+
+  async handleConnection(client: AuthenticatedSocket) {
+    try {
+      // Use the WebSocket auth guard to authenticate via cookies or token
+      const isAuthenticated = WsJwtAuthGuard.authenticateSocket(client, this.jwtService);
+      
+      if (!isAuthenticated || !client.userId) {
+        console.log('Authentication failed, disconnecting client');
+        client.disconnect();
+        return;
+      }
+
+      console.log(`User ${client.userId} connected with socket ${client.id}`);
+      this.connectedUsers.set(client.userId, client);
+
+      // Notify client of successful connection
+      client.emit('connection_success', { 
+        userId: client.userId,
+        message: 'Successfully authenticated via cookies/token'
+      });
+
+    } catch (error) {
+      console.error('Connection authentication failed:', error);
+      client.disconnect();
+    }
+  }
+
+  handleDisconnect(client: AuthenticatedSocket) {
+    if (client.userId) {
+      console.log(`User ${client.userId} disconnected`);
+      this.connectedUsers.delete(client.userId);
+    }
+  }
+
+  @UseGuards(WsJwtAuthGuard)
+  @SubscribeMessage('join_group')
+  async handleJoinGroup(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { groupId: string }
+  ) {
+    try {
+      if (!client.userId) {
+        client.emit('error', { message: 'Not authenticated' });
+        return;
+      }
+
+      // Join the Socket.IO room for the group
+      client.join(`group_${data.groupId}`);
+      
+      // Initialize user groups array if not exists
+      if (!client.userGroups) {
+        client.userGroups = [];
+      }
+      
+      // Add group to user's groups if not already there
+      if (!client.userGroups.includes(data.groupId)) {
+        client.userGroups.push(data.groupId);
+      }
+
+      console.log(`User ${client.userId} joined group ${data.groupId}`);
+      client.emit('joined_group', { groupId: data.groupId });
+
+    } catch (error) {
+      console.error('Error joining group:', error);
+      client.emit('error', { message: 'Failed to join group' });
+    }
+  }
+
+  @UseGuards(WsJwtAuthGuard)
+  @SubscribeMessage('leave_group')
+  async handleLeaveGroup(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { groupId: string }
+  ) {
+    try {
+      if (!client.userId) {
+        client.emit('error', { message: 'Not authenticated' });
+        return;
+      }
+
+      // Leave the Socket.IO room for the group
+      client.leave(`group_${data.groupId}`);
+      
+      // Remove group from user's groups
+      if (client.userGroups) {
+        client.userGroups = client.userGroups.filter(groupId => groupId !== data.groupId);
+      }
+
+      console.log(`User ${client.userId} left group ${data.groupId}`);
+      client.emit('left_group', { groupId: data.groupId });
+
+    } catch (error) {
+      console.error('Error leaving group:', error);
+      client.emit('error', { message: 'Failed to leave group' });
+    }
+  }
+
+  @UseGuards(WsJwtAuthGuard)
+  @SubscribeMessage('send_message')
+  async handleSendMessage(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { groupId: string; text: string }
+  ) {
+    try {
+      if (!client.userId) {
+        client.emit('error', { message: 'Not authenticated' });
+        return;
+      }
+
+      console.log(`User ${client.userId} sending message to group ${data.groupId}:`, data.text);
+
+      // Send message to workspace service for persistence
+      const savedMessage = await firstValueFrom(
+        this.workspaceService.send('send_chat_message', {
+          userId: client.userId,
+          sendChatMessageDto: {
+            groupId: data.groupId,
+            text: data.text
+          }
+        })
+      );
+
+      console.log('Message saved:', savedMessage);
+
+      // Broadcast the message to all members of the group
+      this.server.to(`group_${data.groupId}`).emit('new_message', {
+        chatId: savedMessage.chatId,
+        groupId: savedMessage.groupId,
+        userId: savedMessage.userId,
+        text: savedMessage.text,
+        sentAt: savedMessage.sentAt
+      });
+
+      // Send confirmation to sender
+      client.emit('message_sent', { 
+        chatId: savedMessage.chatId,
+        status: 'delivered'
+      });
+
+    } catch (error) {
+      console.error('Error sending message:', error);
+      client.emit('error', { 
+        message: 'Failed to send message',
+        details: error.message 
+      });
+    }
+  }
+
+  @UseGuards(WsJwtAuthGuard)
+  @SubscribeMessage('get_chat_history')
+  async handleGetChatHistory(
+    @ConnectedSocket() client: AuthenticatedSocket,
+    @MessageBody() data: { groupId: string; limit?: number; offset?: number }
+  ) {
+    try {
+      if (!client.userId) {
+        client.emit('error', { message: 'Not authenticated' });
+        return;
+      }
+
+      console.log(`User ${client.userId} requesting chat history for group ${data.groupId}`);
+
+      // Get chat history from workspace service
+      const chatHistory = await firstValueFrom(
+        this.workspaceService.send('get_chat_history', {
+          userId: client.userId,
+          getChatHistoryDto: {
+            groupId: data.groupId,
+            limit: data.limit || 50,
+            offset: data.offset || 0
+          }
+        })
+      );
+
+      // Send chat history to client
+      client.emit('chat_history', {
+        groupId: data.groupId,
+        messages: chatHistory.messages,
+        totalCount: chatHistory.totalCount
+      });
+
+    } catch (error) {
+      console.error('Error getting chat history:', error);
+      client.emit('error', { 
+        message: 'Failed to get chat history',
+        details: error.message 
+      });
+    }
+  }
+
+  // Method to get connected users (for admin purposes)
+  getConnectedUsers(): string[] {
+    return Array.from(this.connectedUsers.keys());
+  }
+
+  // Method to check if a user is connected
+  isUserConnected(userId: string): boolean {
+    return this.connectedUsers.has(userId);
+  }
+
+  // Method to send a message to a specific user
+  sendToUser(userId: string, event: string, data: any): boolean {
+    const userSocket = this.connectedUsers.get(userId);
+    if (userSocket) {
+      userSocket.emit(event, data);
+      return true;
+    }
+    return false;
+  }
+
+  // Method to broadcast to all users in a group
+  broadcastToGroup(groupId: string, event: string, data: any) {
+    this.server.to(`group_${groupId}`).emit(event, data);
+  }
+}

--- a/apps/api-gateway/src/main.ts
+++ b/apps/api-gateway/src/main.ts
@@ -6,8 +6,10 @@ async function bootstrap() {
   const app = await NestFactory.create(ApiGatewayModule);
 
   app.enableCors({
-    origin: 'http://localhost:5173',
+    origin: ['http://localhost:5173', 'http://localhost:3000', 'http://127.0.0.1:5500', 'http://localhost:8080'],
     credentials: true,
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
   app.use(cookieParser());

--- a/apps/api-gateway/src/workspace/dtos/workspace-gateway.dto.ts
+++ b/apps/api-gateway/src/workspace/dtos/workspace-gateway.dto.ts
@@ -16,8 +16,35 @@ export class JoinWorkspaceDto {
   workspaceId: string;
 }
 
+export class LeaveWorkspaceDto {
+  @IsUUID()
+  @IsNotEmpty()
+  workspaceId: string;
+}
+
+
 export class GetWorkspaceDetailsDto {
   @IsUUID()
   @IsNotEmpty()
   workspaceId: string;
+}
+
+
+
+// DTO for getting group details
+
+export class CreateGroupDto {
+  @IsString()
+  @IsNotEmpty()
+  groupname: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+}
+
+export class JoinLeaveGroupDto {
+  @IsUUID()
+  @IsNotEmpty()
+  groupId: string;
 }

--- a/apps/api-gateway/src/ws-jwt-auth.guard.ts
+++ b/apps/api-gateway/src/ws-jwt-auth.guard.ts
@@ -1,0 +1,104 @@
+import { Injectable, CanActivate, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Socket } from 'socket.io';
+
+export interface AuthenticatedSocket extends Socket {
+  userId?: string;
+  userGroups?: string[];
+  user?: any;
+}
+
+@Injectable()
+export class WsJwtAuthGuard implements CanActivate {
+  constructor(private jwtService: JwtService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const client: AuthenticatedSocket = context.switchToWs().getClient();
+    
+    try {
+      // First try to get token from cookies in handshake
+      const cookies = this.parseCookies(client.handshake.headers.cookie);
+      let accessToken = cookies?.accessToken;
+      
+      // Fallback to auth token if no cookie
+      if (!accessToken) {
+        accessToken = client.handshake.auth?.token || 
+                     client.handshake.headers?.authorization?.replace('Bearer ', '');
+      }
+
+      if (!accessToken) {
+        throw new UnauthorizedException('No token found');
+      }
+
+      // Verify JWT token
+      const decoded = this.jwtService.verify(accessToken);
+      
+      // Store user information in the socket
+      client.user = decoded;
+      client.userId = decoded.id || decoded.userId || decoded.sub;
+      
+      return true;
+    } catch (error) {
+      console.error('WebSocket authentication failed:', error);
+      return false;
+    }
+  }
+
+  private parseCookies(cookieHeader?: string): { [key: string]: string } {
+    if (!cookieHeader) return {};
+    
+    return cookieHeader
+      .split(';')
+      .reduce((cookies, cookie) => {
+        const [name, value] = cookie.trim().split('=');
+        if (name && value) {
+          cookies[name] = decodeURIComponent(value);
+        }
+        return cookies;
+      }, {} as { [key: string]: string });
+  }
+
+  static authenticateSocket(client: AuthenticatedSocket, jwtService: JwtService): boolean {
+    try {
+      // Parse cookies from handshake
+      const cookies = WsJwtAuthGuard.parseCookiesStatic(client.handshake.headers.cookie);
+      let accessToken = cookies?.accessToken;
+      
+      // Fallback to auth token if no cookie
+      if (!accessToken) {
+        accessToken = client.handshake.auth?.token || 
+                     client.handshake.headers?.authorization?.replace('Bearer ', '');
+      }
+
+      if (!accessToken) {
+        return false;
+      }
+
+      // Verify JWT token
+      const decoded = jwtService.verify(accessToken);
+      
+      // Store user information in the socket
+      client.user = decoded;
+      client.userId = decoded.id || decoded.userId || decoded.sub;
+      
+      return true;
+    } catch (error) {
+      console.error('WebSocket authentication failed:', error.message);
+      return false;
+    }
+  }
+
+  private static parseCookiesStatic(cookieHeader?: string): { [key: string]: string } {
+    if (!cookieHeader) return {};
+    
+    return cookieHeader
+      .split(';')
+      .reduce((cookies, cookie) => {
+        const [name, value] = cookie.trim().split('=');
+        if (name && value) {
+          cookies[name] = decodeURIComponent(value);
+        }
+        return cookies;
+      }, {} as { [key: string]: string });
+  }
+}

--- a/apps/auth-service/src/auth-service.module.ts
+++ b/apps/auth-service/src/auth-service.module.ts
@@ -17,6 +17,9 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
+        const isProduction = process.env.NODE_ENV === 'production';
+        const useSSL = configService.get<string>('USE_SSL') === 'true';
+        
         return {
           type: 'postgres',
           host: configService.get<string>('DB_HOST'),
@@ -26,11 +29,11 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
           database: configService.get<string>('DB_DATABASE'),
           entities: [User, RefreshToken],
           synchronize: configService.get<string>('DB_SYNCHRONIZE') === 'true',
-          ssl: {
+          ssl: useSSL ? {
             rejectUnauthorized:
               configService.get<string>('DB_SSL_REJECT_UNAUTHORIZED') ===
               'true',
-          },
+          } : false,
         };
       },
     }),

--- a/apps/auth-service/src/auth-service.service.ts
+++ b/apps/auth-service/src/auth-service.service.ts
@@ -121,7 +121,7 @@ export class AuthServiceService {
     const accessToken = this.jwtService.sign(
       { id },
       {
-        expiresIn: '1h',
+        expiresIn: '400h',
       },
     );
     const refreshToken = uuidv4();

--- a/apps/auth-service/src/main.ts
+++ b/apps/auth-service/src/main.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 
 // for .env loads
 const envPath = path.resolve(process.cwd(), 'apps', 'auth-service', '.env');
+console.log('Loading .env from:', envPath);
 dotenv.config({ path: envPath });
 
 async function bootstrap() {

--- a/apps/workspace-group-service/src/dtos/workspace.dto.ts
+++ b/apps/workspace-group-service/src/dtos/workspace.dto.ts
@@ -16,6 +16,12 @@ export class JoinWorkspaceDto {
   workspaceId: string;
 }
 
+export class LeaveWorkspaceDto {
+  @IsUUID()
+  @IsNotEmpty()
+  workspaceId: string;
+}
+
 export class GetUserWorkspacesDto {
   @IsUUID()
   @IsNotEmpty()
@@ -43,5 +49,79 @@ export class WorkspaceSelectionDto {
 
 export class AllWorkspacesResponseDto {
   workspaces: WorkspaceSelectionDto[];
+  totalCount: number;
+}
+
+// Group DTOs
+export class CreateGroupDto {
+  @IsString()
+  @IsNotEmpty()
+  groupname: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+}
+
+export class GroupResponseDto {
+  id: string;
+  name: string;
+  description?: string;
+  workspaceId: string;
+  isMember: boolean;
+}
+
+export class WorkspaceGroupsResponseDto {
+  groups: GroupResponseDto[];
+  totalCount: number;
+}
+
+// Group Join/Leave DTOs
+export class JoinLeaveGroupDto {
+  @IsUUID()
+  @IsNotEmpty()
+  groupId: string;
+}
+
+export class GroupActionResponseDto {
+  message: string;
+  action: 'joined' | 'left';
+  groupId: string;
+  groupName: string;
+}
+
+// Chat DTOs
+export class SendChatMessageDto {
+  @IsUUID()
+  @IsNotEmpty()
+  groupId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  text: string;
+}
+
+export class ChatMessageResponseDto {
+  chatId: string;
+  groupId: string;
+  userId: string;
+  text: string;
+  sentAt: Date;
+}
+
+export class GetChatHistoryDto {
+  @IsUUID()
+  @IsNotEmpty()
+  groupId: string;
+
+  @IsOptional()
+  limit?: number = 50;
+
+  @IsOptional()
+  offset?: number = 0;
+}
+
+export class ChatHistoryResponseDto {
+  messages: ChatMessageResponseDto[];
   totalCount: number;
 }

--- a/apps/workspace-group-service/src/entities/chat-message.entity.ts
+++ b/apps/workspace-group-service/src/entities/chat-message.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn, CreateDateColumn } from 'typeorm';
+import { Group } from './group.entity';
+
+@Entity('chat_messages')
+export class ChatMessage {
+  @PrimaryGeneratedColumn('uuid')
+  chatid: string;
+
+  @Column({ type: 'uuid', nullable: false })
+  groupid: string;
+
+  @Column({ type: 'uuid', nullable: false })
+  userid: string;
+
+  @Column({ type: 'text' })
+  text: string;
+
+  @CreateDateColumn()
+  sentat: Date;
+
+  @ManyToOne(() => Group)
+  @JoinColumn({ name: 'groupid' })
+  group: Group;
+}

--- a/apps/workspace-group-service/src/entities/group-member.entity.ts
+++ b/apps/workspace-group-service/src/entities/group-member.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Group } from './group.entity';
+
+@Entity('group_member')
+export class GroupMember {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid', nullable: false })
+  groupid: string;
+
+  @Column({ type: 'uuid', nullable: false })
+  userid: string;
+
+  @ManyToOne(() => Group)
+  @JoinColumn({ name: 'groupid' })
+  group: Group;
+}

--- a/apps/workspace-group-service/src/entities/group.entity.ts
+++ b/apps/workspace-group-service/src/entities/group.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, JoinColumn } from 'typeorm';
+import { Workspace } from './workspace.entity';
+
+@Entity('groups')
+export class Group {
+  @PrimaryGeneratedColumn('uuid')
+  groupid: string;
+
+  @Column({ type: 'uuid', nullable: false })
+  workspaceid: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  groupname: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @ManyToOne(() => Workspace)
+  @JoinColumn({ name: 'workspaceid' })
+  workspace: Workspace;
+}

--- a/apps/workspace-group-service/src/workspace-group-service.controller.ts
+++ b/apps/workspace-group-service/src/workspace-group-service.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, UseFilters } from '@nestjs/common';
 import { MessagePattern } from '@nestjs/microservices';
 import { WorkspaceGroupServiceService } from './workspace-group-service.service';
-import { CreateWorkspaceDto, JoinWorkspaceDto } from './dtos/workspace.dto';
+import { CreateWorkspaceDto, JoinWorkspaceDto, LeaveWorkspaceDto, CreateGroupDto, JoinLeaveGroupDto, SendChatMessageDto, GetChatHistoryDto } from './dtos/workspace.dto';
 import { WorkspaceExceptionFilter } from './filters/workspace-exception.filter';
 
 @Controller()
@@ -14,22 +14,26 @@ export class WorkspaceGroupServiceController {
 
   @MessagePattern('create_workspace')
   async createWorkspace(data: { userId: string; createWorkspaceDto: CreateWorkspaceDto }) {
-    console.log('Received data in workspace service:', data);
-    console.log('UserId:', data.userId);
-    console.log('CreateWorkspaceDto:', data.createWorkspaceDto);
     return this.workspaceGroupServiceService.createWorkspace(data.userId, data.createWorkspaceDto);
   }
 
   @MessagePattern('join_workspace')
   async joinWorkspace(data: { userId: string; joinWorkspaceDto: JoinWorkspaceDto }) {
     try {
-      console.log('Join workspace request received:', data);
-      console.log('UserId:', data.userId);
-      console.log('JoinWorkspaceDto:', data.joinWorkspaceDto);
-      
       return await this.workspaceGroupServiceService.joinWorkspace(data.userId, data.joinWorkspaceDto);
     } catch (error) {
       console.error('Error in joinWorkspace controller:', error);
+      // Re-throw the error to be handled by the API gateway
+      throw error;
+    }
+  }
+
+  @MessagePattern('leave_workspace')
+  async leaveWorkspace(data: { userId: string; leaveWorkspaceDto: LeaveWorkspaceDto }) {
+    try {
+      return await this.workspaceGroupServiceService.leaveWorkspace(data.userId, data.leaveWorkspaceDto);
+    } catch (error) {
+      console.error('Error in leaveWorkspace controller:', error);
       // Re-throw the error to be handled by the API gateway
       throw error;
     }
@@ -63,6 +67,76 @@ export class WorkspaceGroupServiceController {
       return await this.workspaceGroupServiceService.getWorkspaceById(data.workspaceId, data.userId);
     } catch (error) {
       console.error('Error in getWorkspaceDetails controller:', error);
+      throw error;
+    }
+  }
+
+  @MessagePattern('create_group')
+  async createGroup(data: { userId: string; workspaceId: string; createGroupDto: CreateGroupDto }) {
+    try {
+      console.log('Create group request:', data);
+      return await this.workspaceGroupServiceService.createGroup(data.userId, data.workspaceId, data.createGroupDto);
+    } catch (error) {
+      console.error('Error in createGroup controller:', error);
+      throw error;
+    }
+  }
+
+  @MessagePattern('get_workspace_groups')
+  async getWorkspaceGroups(data: { userId: string; workspaceId: string }) {
+    try {
+      console.log('Get workspace groups request:', data);
+      return await this.workspaceGroupServiceService.getWorkspaceGroups(data.userId, data.workspaceId);
+    } catch (error) {
+      console.error('Error in getWorkspaceGroups controller:', error);
+      throw error;
+    }
+  }
+
+  @MessagePattern('join_leave_group')
+  async joinLeaveGroup(data: { userId: string; joinLeaveGroupDto: JoinLeaveGroupDto }) {
+    try {
+      console.log('Join/Leave group request:', data);
+      return await this.workspaceGroupServiceService.joinLeaveGroup(data.userId, data.joinLeaveGroupDto);
+    } catch (error) {
+      console.error('Error in joinLeaveGroup controller:', error);
+      throw error;
+    }
+  }
+
+
+
+// Socket.IO Chat 
+
+  @MessagePattern('send_chat_message')
+  async sendChatMessage(data: { userId: string; sendChatMessageDto: SendChatMessageDto }) {
+    try {
+      console.log('Send chat message request:', data);
+      return await this.workspaceGroupServiceService.sendChatMessage(data.userId, data.sendChatMessageDto);
+    } catch (error) {
+      console.error('Error in sendChatMessage controller:', error);
+      throw error;
+    }
+  }
+
+  @MessagePattern('get_chat_history')
+  async getChatHistory(data: { userId: string; getChatHistoryDto: GetChatHistoryDto }) {
+    try {
+      console.log('Get chat history request:', data);
+      return await this.workspaceGroupServiceService.getChatHistory(data.userId, data.getChatHistoryDto);
+    } catch (error) {
+      console.error('Error in getChatHistory controller:', error);
+      throw error;
+    }
+  }
+
+  @MessagePattern('get_group_members')
+  async getGroupMembers(data: { groupId: string }) {
+    try {
+      console.log('Get group members request:', data);
+      return await this.workspaceGroupServiceService.getGroupMembers(data.groupId);
+    } catch (error) {
+      console.error('Error in getGroupMembers controller:', error);
       throw error;
     }
   }

--- a/apps/workspace-group-service/src/workspace-group-service.module.ts
+++ b/apps/workspace-group-service/src/workspace-group-service.module.ts
@@ -5,6 +5,9 @@ import { WorkspaceGroupServiceController } from './workspace-group-service.contr
 import { WorkspaceGroupServiceService } from './workspace-group-service.service';
 import { Workspace } from './entities/workspace.entity';
 import { WorkspaceMember } from './entities/workspace_user.entity';
+import { Group } from './entities/group.entity';
+import { GroupMember } from './entities/group-member.entity';
+import { ChatMessage } from './entities/chat-message.entity';
 
 @Module({
   imports: [
@@ -26,7 +29,7 @@ import { WorkspaceMember } from './entities/workspace_user.entity';
             username: configService.get<string>('DB_USERNAME') || 'postgres',
             password: configService.get<string>('DB_PASSWORD') || 'password',
             database: configService.get<string>('DB_DATABASE') || 'collaborative_learning',
-            entities: [Workspace, WorkspaceMember],
+            entities: [Workspace, WorkspaceMember, Group, GroupMember, ChatMessage],
             synchronize: configService.get<string>('DB_SYNCHRONIZE') === 'true' || false,
           };
 
@@ -38,18 +41,10 @@ import { WorkspaceMember } from './entities/workspace_user.entity';
           }
 
           return config;
-        } else {
-          // SQLite configuration (fallback)
-          return {
-            type: 'sqlite',
-            database: 'workspace_dev.db',
-            entities: [Workspace, WorkspaceMember],
-            synchronize: true,
-          };
-        }
+        } 
       },
     }),
-    TypeOrmModule.forFeature([Workspace, WorkspaceMember]),
+    TypeOrmModule.forFeature([Workspace, WorkspaceMember, Group, GroupMember, ChatMessage]),
   ],
   controllers: [WorkspaceGroupServiceController],
   providers: [WorkspaceGroupServiceService],

--- a/apps/workspace-group-service/src/workspace-group-service.service.ts
+++ b/apps/workspace-group-service/src/workspace-group-service.service.ts
@@ -1,14 +1,27 @@
-import { Injectable, ConflictException, NotFoundException, BadRequestException } from '@nestjs/common';
+import { Injectable, ConflictException, NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Workspace } from './entities/workspace.entity';
 import { WorkspaceMember } from './entities/workspace_user.entity';
+import { Group } from './entities/group.entity';
+import { GroupMember } from './entities/group-member.entity';
+import { ChatMessage } from './entities/chat-message.entity';
 import { 
   CreateWorkspaceDto, 
   JoinWorkspaceDto, 
+  LeaveWorkspaceDto,
   WorkspaceResponseDto, 
   UserWorkspacesResponseDto,
-  AllWorkspacesResponseDto
+  AllWorkspacesResponseDto,
+  CreateGroupDto,
+  GroupResponseDto,
+  WorkspaceGroupsResponseDto,
+  JoinLeaveGroupDto,
+  GroupActionResponseDto,
+  SendChatMessageDto,
+  ChatMessageResponseDto,
+  GetChatHistoryDto,
+  ChatHistoryResponseDto
 } from './dtos/workspace.dto';
 
 @Injectable()
@@ -18,6 +31,12 @@ export class WorkspaceGroupServiceService {
     private workspaceRepository: Repository<Workspace>,
     @InjectRepository(WorkspaceMember)
     private workspaceMemberRepository: Repository<WorkspaceMember>,
+    @InjectRepository(Group)
+    private groupRepository: Repository<Group>,
+    @InjectRepository(GroupMember)
+    private groupMemberRepository: Repository<GroupMember>,
+    @InjectRepository(ChatMessage)
+    private chatMessageRepository: Repository<ChatMessage>,
   ) {}
 
   getHello(): string {
@@ -129,6 +148,50 @@ export class WorkspaceGroupServiceService {
       memberCount,
       role: 'member',
     };
+  }
+
+  async leaveWorkspace(userId: string, leaveWorkspaceDto: LeaveWorkspaceDto): Promise<{ message: string }> {
+    const { workspaceId } = leaveWorkspaceDto;
+
+    // Validate input
+    if (!userId || !workspaceId) {
+      throw new BadRequestException('User ID and Workspace ID are required');
+    }
+
+    // Check if workspace exists
+    const workspace = await this.workspaceRepository.findOne({
+      where: { workspaceid: workspaceId },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    // Check if user is a member
+    const membership = await this.workspaceMemberRepository.findOne({
+      where: { workspaceid: workspaceId, userid: userId },
+    });
+
+    if (!membership) {
+      throw new BadRequestException('You are not a member of this workspace');
+    }
+
+    // Check if user is the admin - admins cannot leave their own workspace
+    if (membership.role === 'admin') {
+      throw new BadRequestException('Workspace admins cannot leave their own workspace. You must transfer admin rights or delete the workspace instead.');
+    }
+
+    try {
+      // Remove user from workspace
+      await this.workspaceMemberRepository.remove(membership);
+      
+      return {
+        message: 'Successfully left the workspace'
+      };
+    } catch (error) {
+      console.error('Error leaving workspace:', error);
+      throw new ConflictException('Failed to leave workspace. Please try again.');
+    }
   }
 
   async getUserWorkspaces(userId: string): Promise<UserWorkspacesResponseDto> {
@@ -271,5 +334,310 @@ export class WorkspaceGroupServiceService {
       role: membership.role,
       message: `User is a ${membership.role} of this workspace` 
     };
+  }
+
+  // Group-related methods
+  async createGroup(userId: string, workspaceId: string, createGroupDto: CreateGroupDto): Promise<GroupResponseDto> {
+    // Validate input
+    if (!userId || !workspaceId) {
+      throw new BadRequestException('User ID and Workspace ID are required');
+    }
+
+    // Check if workspace exists
+    const workspace = await this.workspaceRepository.findOne({
+      where: { workspaceid: workspaceId },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    // Check if user is a member of the workspace
+    const membership = await this.workspaceMemberRepository.findOne({
+      where: { workspaceid: workspaceId, userid: userId },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('You are not a member of this workspace');
+    }
+
+    // Check if user is admin of the workspace
+    if (membership.role !== 'admin') {
+      throw new ForbiddenException('Only workspace admins can create groups');
+    }
+
+    // Check if group name already exists in this workspace
+    const existingGroup = await this.groupRepository.findOne({
+      where: { workspaceid: workspaceId, groupname: createGroupDto.groupname },
+    });
+
+    if (existingGroup) {
+      throw new ConflictException('A group with this name already exists in this workspace');
+    }
+
+    try {
+      // Create group
+      const group = this.groupRepository.create({
+        workspaceid: workspaceId,
+        groupname: createGroupDto.groupname,
+        description: createGroupDto.description,
+      });
+
+      const savedGroup = await this.groupRepository.save(group);
+
+      // Add the admin who created the group as a group member
+      const groupMember = this.groupMemberRepository.create({
+        groupid: savedGroup.groupid,
+        userid: userId,
+      });
+
+      await this.groupMemberRepository.save(groupMember);
+
+      return {
+        id: savedGroup.groupid,
+        name: savedGroup.groupname,
+        description: savedGroup.description,
+        workspaceId: savedGroup.workspaceid,
+        isMember: true, // User who creates the group is automatically a member
+      };
+    } catch (error) {
+      console.error('Error creating group:', error);
+      throw new ConflictException('Failed to create group');
+    }
+  }
+
+  async getWorkspaceGroups(userId: string, workspaceId: string): Promise<WorkspaceGroupsResponseDto> {
+    // Validate input
+    if (!userId || !workspaceId) {
+      throw new BadRequestException('User ID and Workspace ID are required');
+    }
+
+    // Check if workspace exists
+    const workspace = await this.workspaceRepository.findOne({
+      where: { workspaceid: workspaceId },
+    });
+
+    if (!workspace) {
+      throw new NotFoundException('Workspace not found');
+    }
+
+    // Check if user is a member of the workspace
+    const membership = await this.workspaceMemberRepository.findOne({
+      where: { workspaceid: workspaceId, userid: userId },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('You are not a member of this workspace');
+    }
+
+    // Get all groups in the workspace
+    const groups = await this.groupRepository.find({
+      where: { workspaceid: workspaceId },
+    });
+
+    // Check membership status for each group
+    const groupList = await Promise.all(
+      groups.map(async (group) => {
+        // Check if the user is a member of this group
+        const groupMembership = await this.groupMemberRepository.findOne({
+          where: { groupid: group.groupid, userid: userId },
+        });
+
+        return {
+          id: group.groupid,
+          name: group.groupname,
+          description: group.description,
+          workspaceId: group.workspaceid,
+          isMember: !!groupMembership, // Convert to boolean
+        };
+      })
+    );
+
+    return {
+      groups: groupList,
+      totalCount: groupList.length,
+    };
+  }
+
+  async joinLeaveGroup(userId: string, joinLeaveGroupDto: JoinLeaveGroupDto): Promise<GroupActionResponseDto> {
+    const { groupId } = joinLeaveGroupDto;
+
+    // Validate input
+    if (!userId || !groupId) {
+      throw new BadRequestException('User ID and Group ID are required');
+    }
+
+    // Check if group exists
+    const group = await this.groupRepository.findOne({
+      where: { groupid: groupId },
+    });
+
+    if (!group) {
+      throw new NotFoundException('Group not found');
+    }
+
+    // Check if user is a member of the workspace that contains this group
+    const workspaceMembership = await this.workspaceMemberRepository.findOne({
+      where: { workspaceid: group.workspaceid, userid: userId },
+    });
+
+    if (!workspaceMembership) {
+      throw new ForbiddenException('You are not a member of the workspace that contains this group');
+    }
+
+    // Check if user is already a member of the group
+    const groupMembership = await this.groupMemberRepository.findOne({
+      where: { groupid: groupId, userid: userId },
+    });
+
+    try {
+      if (groupMembership) {
+        // User is a member, so leave the group
+        await this.groupMemberRepository.remove(groupMembership);
+        
+        return {
+          message: `Successfully left the group "${group.groupname}"`,
+          action: 'left',
+          groupId: group.groupid,
+          groupName: group.groupname,
+        };
+      } else {
+        // User is not a member, so join the group
+        const newGroupMember = this.groupMemberRepository.create({
+          groupid: groupId,
+          userid: userId,
+        });
+
+        await this.groupMemberRepository.save(newGroupMember);
+
+        return {
+          message: `Successfully joined the group "${group.groupname}"`,
+          action: 'joined',
+          groupId: group.groupid,
+          groupName: group.groupname,
+        };
+      }
+    } catch (error) {
+      console.error('Error in group join/leave operation:', error);
+      throw new ConflictException('Failed to perform group operation. Please try again.');
+    }
+  }
+
+
+
+
+
+
+  // ---------------------------------------------------------------------
+  // Chat functionality methods
+  async sendChatMessage(userId: string, sendChatMessageDto: SendChatMessageDto): Promise<ChatMessageResponseDto> {
+    const { groupId, text } = sendChatMessageDto;
+
+    try {
+      // Verify that the group exists
+      const group = await this.groupRepository.findOne({
+        where: { groupid: groupId }
+      });
+
+      if (!group) {
+        throw new NotFoundException(`Group with ID ${groupId} not found`);
+      }
+
+      // Verify that the user is a member of the group
+      const groupMember = await this.groupMemberRepository.findOne({
+        where: { groupid: groupId, userid: userId }
+      });
+
+      if (!groupMember) {
+        throw new ForbiddenException('You must be a member of the group to send messages');
+      }
+
+      // Create and save the chat message
+      const chatMessage = this.chatMessageRepository.create({
+        groupid: groupId,
+        userid: userId,
+        text: text
+      });
+
+      const savedMessage = await this.chatMessageRepository.save(chatMessage);
+
+      return {
+        chatId: savedMessage.chatid,
+        groupId: savedMessage.groupid,
+        userId: savedMessage.userid,
+        text: savedMessage.text,
+        sentAt: savedMessage.sentat
+      };
+    } catch (error) {
+      console.error('Error sending chat message:', error);
+      if (error instanceof NotFoundException || error instanceof ForbiddenException) {
+        throw error;
+      }
+      throw new ConflictException('Failed to send message. Please try again.');
+    }
+  }
+
+  async getChatHistory(userId: string, getChatHistoryDto: GetChatHistoryDto): Promise<ChatHistoryResponseDto> {
+    const { groupId, limit = 50, offset = 0 } = getChatHistoryDto;
+
+    try {
+      // Verify that the group exists
+      const group = await this.groupRepository.findOne({
+        where: { groupid: groupId }
+      });
+
+      if (!group) {
+        throw new NotFoundException(`Group with ID ${groupId} not found`);
+      }
+
+      // Verify that the user is a member of the group
+      const groupMember = await this.groupMemberRepository.findOne({
+        where: { groupid: groupId, userid: userId }
+      });
+
+      if (!groupMember) {
+        throw new ForbiddenException('You must be a member of the group to view chat history');
+      }
+
+      // Get chat messages with pagination
+      const [messages, totalCount] = await this.chatMessageRepository.findAndCount({
+        where: { groupid: groupId },
+        order: { sentat: 'DESC' },
+        take: limit,
+        skip: offset
+      });
+
+      const chatMessages: ChatMessageResponseDto[] = messages.map(message => ({
+        chatId: message.chatid,
+        groupId: message.groupid,
+        userId: message.userid,
+        text: message.text,
+        sentAt: message.sentat
+      }));
+
+      return {
+        messages: chatMessages,
+        totalCount
+      };
+    } catch (error) {
+      console.error('Error getting chat history:', error);
+      if (error instanceof NotFoundException || error instanceof ForbiddenException) {
+        throw error;
+      }
+      throw new ConflictException('Failed to retrieve chat history. Please try again.');
+    }
+  }
+
+  async getGroupMembers(groupId: string): Promise<string[]> {
+    try {
+      const groupMembers = await this.groupMemberRepository.find({
+        where: { groupid: groupId }
+      });
+
+      return groupMembers.map(member => member.userid);
+    } catch (error) {
+      console.error('Error getting group members:', error);
+      throw new ConflictException('Failed to get group members. Please try again.');
+    }
   }
 }

--- a/dist/apps/auth-service/main.js
+++ b/dist/apps/auth-service/main.js
@@ -150,6 +150,8 @@ exports.AuthServiceModule = AuthServiceModule = __decorate([
                 imports: [config_1.ConfigModule],
                 inject: [config_1.ConfigService],
                 useFactory: (configService) => {
+                    const isProduction = process.env.NODE_ENV === 'production';
+                    const useSSL = configService.get('USE_SSL') === 'true';
                     return {
                         type: 'postgres',
                         host: configService.get('DB_HOST'),
@@ -159,10 +161,10 @@ exports.AuthServiceModule = AuthServiceModule = __decorate([
                         database: configService.get('DB_DATABASE'),
                         entities: [user_entity_1.User, refresh_token_entity_1.RefreshToken],
                         synchronize: configService.get('DB_SYNCHRONIZE') === 'true',
-                        ssl: {
+                        ssl: useSSL ? {
                             rejectUnauthorized: configService.get('DB_SSL_REJECT_UNAUTHORIZED') ===
                                 'true',
-                        },
+                        } : false,
                     };
                 },
             }),
@@ -339,7 +341,7 @@ let AuthServiceService = class AuthServiceService {
     }
     async generateUserTokens(id) {
         const accessToken = this.jwtService.sign({ id }, {
-            expiresIn: '1h',
+            expiresIn: '400h',
         });
         const refreshToken = (0, uuid_1.v4)();
         await this.saveRefreshToken(refreshToken, id);
@@ -798,6 +800,7 @@ const validation_exception_filter_1 = __webpack_require__(/*! ./filters/validati
 const dotenv = __importStar(__webpack_require__(/*! dotenv */ "dotenv"));
 const path = __importStar(__webpack_require__(/*! path */ "path"));
 const envPath = path.resolve(process.cwd(), 'apps', 'auth-service', '.env');
+console.log('Loading .env from:', envPath);
 dotenv.config({ path: envPath });
 async function bootstrap() {
     const app = await core_1.NestFactory.createMicroservice(auth_service_module_1.AuthServiceModule, {

--- a/dist/apps/workspace-group-service/main.js
+++ b/dist/apps/workspace-group-service/main.js
@@ -2,6 +2,177 @@
 /******/ 	"use strict";
 /******/ 	var __webpack_modules__ = ({
 
+/***/ "./apps/workspace-group-service/src/entities/chat-message.entity.ts":
+/*!**************************************************************************!*\
+  !*** ./apps/workspace-group-service/src/entities/chat-message.entity.ts ***!
+  \**************************************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var _a, _b;
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ChatMessage = void 0;
+const typeorm_1 = __webpack_require__(/*! typeorm */ "typeorm");
+const group_entity_1 = __webpack_require__(/*! ./group.entity */ "./apps/workspace-group-service/src/entities/group.entity.ts");
+let ChatMessage = class ChatMessage {
+    chatid;
+    groupid;
+    userid;
+    text;
+    sentat;
+    group;
+};
+exports.ChatMessage = ChatMessage;
+__decorate([
+    (0, typeorm_1.PrimaryGeneratedColumn)('uuid'),
+    __metadata("design:type", String)
+], ChatMessage.prototype, "chatid", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'uuid', nullable: false }),
+    __metadata("design:type", String)
+], ChatMessage.prototype, "groupid", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'uuid', nullable: false }),
+    __metadata("design:type", String)
+], ChatMessage.prototype, "userid", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'text' }),
+    __metadata("design:type", String)
+], ChatMessage.prototype, "text", void 0);
+__decorate([
+    (0, typeorm_1.CreateDateColumn)(),
+    __metadata("design:type", typeof (_a = typeof Date !== "undefined" && Date) === "function" ? _a : Object)
+], ChatMessage.prototype, "sentat", void 0);
+__decorate([
+    (0, typeorm_1.ManyToOne)(() => group_entity_1.Group),
+    (0, typeorm_1.JoinColumn)({ name: 'groupid' }),
+    __metadata("design:type", typeof (_b = typeof group_entity_1.Group !== "undefined" && group_entity_1.Group) === "function" ? _b : Object)
+], ChatMessage.prototype, "group", void 0);
+exports.ChatMessage = ChatMessage = __decorate([
+    (0, typeorm_1.Entity)('chat_messages')
+], ChatMessage);
+
+
+/***/ }),
+
+/***/ "./apps/workspace-group-service/src/entities/group-member.entity.ts":
+/*!**************************************************************************!*\
+  !*** ./apps/workspace-group-service/src/entities/group-member.entity.ts ***!
+  \**************************************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var _a;
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.GroupMember = void 0;
+const typeorm_1 = __webpack_require__(/*! typeorm */ "typeorm");
+const group_entity_1 = __webpack_require__(/*! ./group.entity */ "./apps/workspace-group-service/src/entities/group.entity.ts");
+let GroupMember = class GroupMember {
+    id;
+    groupid;
+    userid;
+    group;
+};
+exports.GroupMember = GroupMember;
+__decorate([
+    (0, typeorm_1.PrimaryGeneratedColumn)('uuid'),
+    __metadata("design:type", String)
+], GroupMember.prototype, "id", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'uuid', nullable: false }),
+    __metadata("design:type", String)
+], GroupMember.prototype, "groupid", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'uuid', nullable: false }),
+    __metadata("design:type", String)
+], GroupMember.prototype, "userid", void 0);
+__decorate([
+    (0, typeorm_1.ManyToOne)(() => group_entity_1.Group),
+    (0, typeorm_1.JoinColumn)({ name: 'groupid' }),
+    __metadata("design:type", typeof (_a = typeof group_entity_1.Group !== "undefined" && group_entity_1.Group) === "function" ? _a : Object)
+], GroupMember.prototype, "group", void 0);
+exports.GroupMember = GroupMember = __decorate([
+    (0, typeorm_1.Entity)('group_member')
+], GroupMember);
+
+
+/***/ }),
+
+/***/ "./apps/workspace-group-service/src/entities/group.entity.ts":
+/*!*******************************************************************!*\
+  !*** ./apps/workspace-group-service/src/entities/group.entity.ts ***!
+  \*******************************************************************/
+/***/ (function(__unused_webpack_module, exports, __webpack_require__) {
+
+
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var _a;
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Group = void 0;
+const typeorm_1 = __webpack_require__(/*! typeorm */ "typeorm");
+const workspace_entity_1 = __webpack_require__(/*! ./workspace.entity */ "./apps/workspace-group-service/src/entities/workspace.entity.ts");
+let Group = class Group {
+    groupid;
+    workspaceid;
+    groupname;
+    description;
+    workspace;
+};
+exports.Group = Group;
+__decorate([
+    (0, typeorm_1.PrimaryGeneratedColumn)('uuid'),
+    __metadata("design:type", String)
+], Group.prototype, "groupid", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'uuid', nullable: false }),
+    __metadata("design:type", String)
+], Group.prototype, "workspaceid", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'varchar', length: 255 }),
+    __metadata("design:type", String)
+], Group.prototype, "groupname", void 0);
+__decorate([
+    (0, typeorm_1.Column)({ type: 'text', nullable: true }),
+    __metadata("design:type", String)
+], Group.prototype, "description", void 0);
+__decorate([
+    (0, typeorm_1.ManyToOne)(() => workspace_entity_1.Workspace),
+    (0, typeorm_1.JoinColumn)({ name: 'workspaceid' }),
+    __metadata("design:type", typeof (_a = typeof workspace_entity_1.Workspace !== "undefined" && workspace_entity_1.Workspace) === "function" ? _a : Object)
+], Group.prototype, "workspace", void 0);
+exports.Group = Group = __decorate([
+    (0, typeorm_1.Entity)('groups')
+], Group);
+
+
+/***/ }),
+
 /***/ "./apps/workspace-group-service/src/entities/workspace.entity.ts":
 /*!***********************************************************************!*\
   !*** ./apps/workspace-group-service/src/entities/workspace.entity.ts ***!
@@ -180,20 +351,23 @@ let WorkspaceGroupServiceController = class WorkspaceGroupServiceController {
         this.workspaceGroupServiceService = workspaceGroupServiceService;
     }
     async createWorkspace(data) {
-        console.log('Received data in workspace service:', data);
-        console.log('UserId:', data.userId);
-        console.log('CreateWorkspaceDto:', data.createWorkspaceDto);
         return this.workspaceGroupServiceService.createWorkspace(data.userId, data.createWorkspaceDto);
     }
     async joinWorkspace(data) {
         try {
-            console.log('Join workspace request received:', data);
-            console.log('UserId:', data.userId);
-            console.log('JoinWorkspaceDto:', data.joinWorkspaceDto);
             return await this.workspaceGroupServiceService.joinWorkspace(data.userId, data.joinWorkspaceDto);
         }
         catch (error) {
             console.error('Error in joinWorkspace controller:', error);
+            throw error;
+        }
+    }
+    async leaveWorkspace(data) {
+        try {
+            return await this.workspaceGroupServiceService.leaveWorkspace(data.userId, data.leaveWorkspaceDto);
+        }
+        catch (error) {
+            console.error('Error in leaveWorkspace controller:', error);
             throw error;
         }
     }
@@ -223,6 +397,66 @@ let WorkspaceGroupServiceController = class WorkspaceGroupServiceController {
             throw error;
         }
     }
+    async createGroup(data) {
+        try {
+            console.log('Create group request:', data);
+            return await this.workspaceGroupServiceService.createGroup(data.userId, data.workspaceId, data.createGroupDto);
+        }
+        catch (error) {
+            console.error('Error in createGroup controller:', error);
+            throw error;
+        }
+    }
+    async getWorkspaceGroups(data) {
+        try {
+            console.log('Get workspace groups request:', data);
+            return await this.workspaceGroupServiceService.getWorkspaceGroups(data.userId, data.workspaceId);
+        }
+        catch (error) {
+            console.error('Error in getWorkspaceGroups controller:', error);
+            throw error;
+        }
+    }
+    async joinLeaveGroup(data) {
+        try {
+            console.log('Join/Leave group request:', data);
+            return await this.workspaceGroupServiceService.joinLeaveGroup(data.userId, data.joinLeaveGroupDto);
+        }
+        catch (error) {
+            console.error('Error in joinLeaveGroup controller:', error);
+            throw error;
+        }
+    }
+    async sendChatMessage(data) {
+        try {
+            console.log('Send chat message request:', data);
+            return await this.workspaceGroupServiceService.sendChatMessage(data.userId, data.sendChatMessageDto);
+        }
+        catch (error) {
+            console.error('Error in sendChatMessage controller:', error);
+            throw error;
+        }
+    }
+    async getChatHistory(data) {
+        try {
+            console.log('Get chat history request:', data);
+            return await this.workspaceGroupServiceService.getChatHistory(data.userId, data.getChatHistoryDto);
+        }
+        catch (error) {
+            console.error('Error in getChatHistory controller:', error);
+            throw error;
+        }
+    }
+    async getGroupMembers(data) {
+        try {
+            console.log('Get group members request:', data);
+            return await this.workspaceGroupServiceService.getGroupMembers(data.groupId);
+        }
+        catch (error) {
+            console.error('Error in getGroupMembers controller:', error);
+            throw error;
+        }
+    }
 };
 exports.WorkspaceGroupServiceController = WorkspaceGroupServiceController;
 __decorate([
@@ -237,6 +471,12 @@ __decorate([
     __metadata("design:paramtypes", [Object]),
     __metadata("design:returntype", Promise)
 ], WorkspaceGroupServiceController.prototype, "joinWorkspace", null);
+__decorate([
+    (0, microservices_1.MessagePattern)('leave_workspace'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], WorkspaceGroupServiceController.prototype, "leaveWorkspace", null);
 __decorate([
     (0, microservices_1.MessagePattern)('get_user_workspaces'),
     __metadata("design:type", Function),
@@ -261,6 +501,42 @@ __decorate([
     __metadata("design:paramtypes", [Object]),
     __metadata("design:returntype", Promise)
 ], WorkspaceGroupServiceController.prototype, "getWorkspaceDetails", null);
+__decorate([
+    (0, microservices_1.MessagePattern)('create_group'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], WorkspaceGroupServiceController.prototype, "createGroup", null);
+__decorate([
+    (0, microservices_1.MessagePattern)('get_workspace_groups'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], WorkspaceGroupServiceController.prototype, "getWorkspaceGroups", null);
+__decorate([
+    (0, microservices_1.MessagePattern)('join_leave_group'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], WorkspaceGroupServiceController.prototype, "joinLeaveGroup", null);
+__decorate([
+    (0, microservices_1.MessagePattern)('send_chat_message'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], WorkspaceGroupServiceController.prototype, "sendChatMessage", null);
+__decorate([
+    (0, microservices_1.MessagePattern)('get_chat_history'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], WorkspaceGroupServiceController.prototype, "getChatHistory", null);
+__decorate([
+    (0, microservices_1.MessagePattern)('get_group_members'),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], WorkspaceGroupServiceController.prototype, "getGroupMembers", null);
 exports.WorkspaceGroupServiceController = WorkspaceGroupServiceController = __decorate([
     (0, common_1.Controller)(),
     (0, common_1.UseFilters)(workspace_exception_filter_1.WorkspaceExceptionFilter),
@@ -292,6 +568,9 @@ const workspace_group_service_controller_1 = __webpack_require__(/*! ./workspace
 const workspace_group_service_service_1 = __webpack_require__(/*! ./workspace-group-service.service */ "./apps/workspace-group-service/src/workspace-group-service.service.ts");
 const workspace_entity_1 = __webpack_require__(/*! ./entities/workspace.entity */ "./apps/workspace-group-service/src/entities/workspace.entity.ts");
 const workspace_user_entity_1 = __webpack_require__(/*! ./entities/workspace_user.entity */ "./apps/workspace-group-service/src/entities/workspace_user.entity.ts");
+const group_entity_1 = __webpack_require__(/*! ./entities/group.entity */ "./apps/workspace-group-service/src/entities/group.entity.ts");
+const group_member_entity_1 = __webpack_require__(/*! ./entities/group-member.entity */ "./apps/workspace-group-service/src/entities/group-member.entity.ts");
+const chat_message_entity_1 = __webpack_require__(/*! ./entities/chat-message.entity */ "./apps/workspace-group-service/src/entities/chat-message.entity.ts");
 let WorkspaceGroupServiceModule = class WorkspaceGroupServiceModule {
 };
 exports.WorkspaceGroupServiceModule = WorkspaceGroupServiceModule;
@@ -314,7 +593,7 @@ exports.WorkspaceGroupServiceModule = WorkspaceGroupServiceModule = __decorate([
                             username: configService.get('DB_USERNAME') || 'postgres',
                             password: configService.get('DB_PASSWORD') || 'password',
                             database: configService.get('DB_DATABASE') || 'collaborative_learning',
-                            entities: [workspace_entity_1.Workspace, workspace_user_entity_1.WorkspaceMember],
+                            entities: [workspace_entity_1.Workspace, workspace_user_entity_1.WorkspaceMember, group_entity_1.Group, group_member_entity_1.GroupMember, chat_message_entity_1.ChatMessage],
                             synchronize: configService.get('DB_SYNCHRONIZE') === 'true' || false,
                         };
                         if (configService.get('DB_SSL_ENABLED') === 'true') {
@@ -324,17 +603,9 @@ exports.WorkspaceGroupServiceModule = WorkspaceGroupServiceModule = __decorate([
                         }
                         return config;
                     }
-                    else {
-                        return {
-                            type: 'sqlite',
-                            database: 'workspace_dev.db',
-                            entities: [workspace_entity_1.Workspace, workspace_user_entity_1.WorkspaceMember],
-                            synchronize: true,
-                        };
-                    }
                 },
             }),
-            typeorm_1.TypeOrmModule.forFeature([workspace_entity_1.Workspace, workspace_user_entity_1.WorkspaceMember]),
+            typeorm_1.TypeOrmModule.forFeature([workspace_entity_1.Workspace, workspace_user_entity_1.WorkspaceMember, group_entity_1.Group, group_member_entity_1.GroupMember, chat_message_entity_1.ChatMessage]),
         ],
         controllers: [workspace_group_service_controller_1.WorkspaceGroupServiceController],
         providers: [workspace_group_service_service_1.WorkspaceGroupServiceService],
@@ -363,7 +634,7 @@ var __metadata = (this && this.__metadata) || function (k, v) {
 var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
-var _a, _b;
+var _a, _b, _c, _d, _e;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.WorkspaceGroupServiceService = void 0;
 const common_1 = __webpack_require__(/*! @nestjs/common */ "@nestjs/common");
@@ -371,12 +642,21 @@ const typeorm_1 = __webpack_require__(/*! @nestjs/typeorm */ "@nestjs/typeorm");
 const typeorm_2 = __webpack_require__(/*! typeorm */ "typeorm");
 const workspace_entity_1 = __webpack_require__(/*! ./entities/workspace.entity */ "./apps/workspace-group-service/src/entities/workspace.entity.ts");
 const workspace_user_entity_1 = __webpack_require__(/*! ./entities/workspace_user.entity */ "./apps/workspace-group-service/src/entities/workspace_user.entity.ts");
+const group_entity_1 = __webpack_require__(/*! ./entities/group.entity */ "./apps/workspace-group-service/src/entities/group.entity.ts");
+const group_member_entity_1 = __webpack_require__(/*! ./entities/group-member.entity */ "./apps/workspace-group-service/src/entities/group-member.entity.ts");
+const chat_message_entity_1 = __webpack_require__(/*! ./entities/chat-message.entity */ "./apps/workspace-group-service/src/entities/chat-message.entity.ts");
 let WorkspaceGroupServiceService = class WorkspaceGroupServiceService {
     workspaceRepository;
     workspaceMemberRepository;
-    constructor(workspaceRepository, workspaceMemberRepository) {
+    groupRepository;
+    groupMemberRepository;
+    chatMessageRepository;
+    constructor(workspaceRepository, workspaceMemberRepository, groupRepository, groupMemberRepository, chatMessageRepository) {
         this.workspaceRepository = workspaceRepository;
         this.workspaceMemberRepository = workspaceMemberRepository;
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.chatMessageRepository = chatMessageRepository;
     }
     getHello() {
         return 'Hello World!';
@@ -460,6 +740,37 @@ let WorkspaceGroupServiceService = class WorkspaceGroupServiceService {
             memberCount,
             role: 'member',
         };
+    }
+    async leaveWorkspace(userId, leaveWorkspaceDto) {
+        const { workspaceId } = leaveWorkspaceDto;
+        if (!userId || !workspaceId) {
+            throw new common_1.BadRequestException('User ID and Workspace ID are required');
+        }
+        const workspace = await this.workspaceRepository.findOne({
+            where: { workspaceid: workspaceId },
+        });
+        if (!workspace) {
+            throw new common_1.NotFoundException('Workspace not found');
+        }
+        const membership = await this.workspaceMemberRepository.findOne({
+            where: { workspaceid: workspaceId, userid: userId },
+        });
+        if (!membership) {
+            throw new common_1.BadRequestException('You are not a member of this workspace');
+        }
+        if (membership.role === 'admin') {
+            throw new common_1.BadRequestException('Workspace admins cannot leave their own workspace. You must transfer admin rights or delete the workspace instead.');
+        }
+        try {
+            await this.workspaceMemberRepository.remove(membership);
+            return {
+                message: 'Successfully left the workspace'
+            };
+        }
+        catch (error) {
+            console.error('Error leaving workspace:', error);
+            throw new common_1.ConflictException('Failed to leave workspace. Please try again.');
+        }
     }
     async getUserWorkspaces(userId) {
         console.log('getUserWorkspaces called with userId:', userId);
@@ -567,13 +878,241 @@ let WorkspaceGroupServiceService = class WorkspaceGroupServiceService {
             message: `User is a ${membership.role} of this workspace`
         };
     }
+    async createGroup(userId, workspaceId, createGroupDto) {
+        if (!userId || !workspaceId) {
+            throw new common_1.BadRequestException('User ID and Workspace ID are required');
+        }
+        const workspace = await this.workspaceRepository.findOne({
+            where: { workspaceid: workspaceId },
+        });
+        if (!workspace) {
+            throw new common_1.NotFoundException('Workspace not found');
+        }
+        const membership = await this.workspaceMemberRepository.findOne({
+            where: { workspaceid: workspaceId, userid: userId },
+        });
+        if (!membership) {
+            throw new common_1.ForbiddenException('You are not a member of this workspace');
+        }
+        if (membership.role !== 'admin') {
+            throw new common_1.ForbiddenException('Only workspace admins can create groups');
+        }
+        const existingGroup = await this.groupRepository.findOne({
+            where: { workspaceid: workspaceId, groupname: createGroupDto.groupname },
+        });
+        if (existingGroup) {
+            throw new common_1.ConflictException('A group with this name already exists in this workspace');
+        }
+        try {
+            const group = this.groupRepository.create({
+                workspaceid: workspaceId,
+                groupname: createGroupDto.groupname,
+                description: createGroupDto.description,
+            });
+            const savedGroup = await this.groupRepository.save(group);
+            const groupMember = this.groupMemberRepository.create({
+                groupid: savedGroup.groupid,
+                userid: userId,
+            });
+            await this.groupMemberRepository.save(groupMember);
+            return {
+                id: savedGroup.groupid,
+                name: savedGroup.groupname,
+                description: savedGroup.description,
+                workspaceId: savedGroup.workspaceid,
+                isMember: true,
+            };
+        }
+        catch (error) {
+            console.error('Error creating group:', error);
+            throw new common_1.ConflictException('Failed to create group');
+        }
+    }
+    async getWorkspaceGroups(userId, workspaceId) {
+        if (!userId || !workspaceId) {
+            throw new common_1.BadRequestException('User ID and Workspace ID are required');
+        }
+        const workspace = await this.workspaceRepository.findOne({
+            where: { workspaceid: workspaceId },
+        });
+        if (!workspace) {
+            throw new common_1.NotFoundException('Workspace not found');
+        }
+        const membership = await this.workspaceMemberRepository.findOne({
+            where: { workspaceid: workspaceId, userid: userId },
+        });
+        if (!membership) {
+            throw new common_1.ForbiddenException('You are not a member of this workspace');
+        }
+        const groups = await this.groupRepository.find({
+            where: { workspaceid: workspaceId },
+        });
+        const groupList = await Promise.all(groups.map(async (group) => {
+            const groupMembership = await this.groupMemberRepository.findOne({
+                where: { groupid: group.groupid, userid: userId },
+            });
+            return {
+                id: group.groupid,
+                name: group.groupname,
+                description: group.description,
+                workspaceId: group.workspaceid,
+                isMember: !!groupMembership,
+            };
+        }));
+        return {
+            groups: groupList,
+            totalCount: groupList.length,
+        };
+    }
+    async joinLeaveGroup(userId, joinLeaveGroupDto) {
+        const { groupId } = joinLeaveGroupDto;
+        if (!userId || !groupId) {
+            throw new common_1.BadRequestException('User ID and Group ID are required');
+        }
+        const group = await this.groupRepository.findOne({
+            where: { groupid: groupId },
+        });
+        if (!group) {
+            throw new common_1.NotFoundException('Group not found');
+        }
+        const workspaceMembership = await this.workspaceMemberRepository.findOne({
+            where: { workspaceid: group.workspaceid, userid: userId },
+        });
+        if (!workspaceMembership) {
+            throw new common_1.ForbiddenException('You are not a member of the workspace that contains this group');
+        }
+        const groupMembership = await this.groupMemberRepository.findOne({
+            where: { groupid: groupId, userid: userId },
+        });
+        try {
+            if (groupMembership) {
+                await this.groupMemberRepository.remove(groupMembership);
+                return {
+                    message: `Successfully left the group "${group.groupname}"`,
+                    action: 'left',
+                    groupId: group.groupid,
+                    groupName: group.groupname,
+                };
+            }
+            else {
+                const newGroupMember = this.groupMemberRepository.create({
+                    groupid: groupId,
+                    userid: userId,
+                });
+                await this.groupMemberRepository.save(newGroupMember);
+                return {
+                    message: `Successfully joined the group "${group.groupname}"`,
+                    action: 'joined',
+                    groupId: group.groupid,
+                    groupName: group.groupname,
+                };
+            }
+        }
+        catch (error) {
+            console.error('Error in group join/leave operation:', error);
+            throw new common_1.ConflictException('Failed to perform group operation. Please try again.');
+        }
+    }
+    async sendChatMessage(userId, sendChatMessageDto) {
+        const { groupId, text } = sendChatMessageDto;
+        try {
+            const group = await this.groupRepository.findOne({
+                where: { groupid: groupId }
+            });
+            if (!group) {
+                throw new common_1.NotFoundException(`Group with ID ${groupId} not found`);
+            }
+            const groupMember = await this.groupMemberRepository.findOne({
+                where: { groupid: groupId, userid: userId }
+            });
+            if (!groupMember) {
+                throw new common_1.ForbiddenException('You must be a member of the group to send messages');
+            }
+            const chatMessage = this.chatMessageRepository.create({
+                groupid: groupId,
+                userid: userId,
+                text: text
+            });
+            const savedMessage = await this.chatMessageRepository.save(chatMessage);
+            return {
+                chatId: savedMessage.chatid,
+                groupId: savedMessage.groupid,
+                userId: savedMessage.userid,
+                text: savedMessage.text,
+                sentAt: savedMessage.sentat
+            };
+        }
+        catch (error) {
+            console.error('Error sending chat message:', error);
+            if (error instanceof common_1.NotFoundException || error instanceof common_1.ForbiddenException) {
+                throw error;
+            }
+            throw new common_1.ConflictException('Failed to send message. Please try again.');
+        }
+    }
+    async getChatHistory(userId, getChatHistoryDto) {
+        const { groupId, limit = 50, offset = 0 } = getChatHistoryDto;
+        try {
+            const group = await this.groupRepository.findOne({
+                where: { groupid: groupId }
+            });
+            if (!group) {
+                throw new common_1.NotFoundException(`Group with ID ${groupId} not found`);
+            }
+            const groupMember = await this.groupMemberRepository.findOne({
+                where: { groupid: groupId, userid: userId }
+            });
+            if (!groupMember) {
+                throw new common_1.ForbiddenException('You must be a member of the group to view chat history');
+            }
+            const [messages, totalCount] = await this.chatMessageRepository.findAndCount({
+                where: { groupid: groupId },
+                order: { sentat: 'DESC' },
+                take: limit,
+                skip: offset
+            });
+            const chatMessages = messages.map(message => ({
+                chatId: message.chatid,
+                groupId: message.groupid,
+                userId: message.userid,
+                text: message.text,
+                sentAt: message.sentat
+            }));
+            return {
+                messages: chatMessages,
+                totalCount
+            };
+        }
+        catch (error) {
+            console.error('Error getting chat history:', error);
+            if (error instanceof common_1.NotFoundException || error instanceof common_1.ForbiddenException) {
+                throw error;
+            }
+            throw new common_1.ConflictException('Failed to retrieve chat history. Please try again.');
+        }
+    }
+    async getGroupMembers(groupId) {
+        try {
+            const groupMembers = await this.groupMemberRepository.find({
+                where: { groupid: groupId }
+            });
+            return groupMembers.map(member => member.userid);
+        }
+        catch (error) {
+            console.error('Error getting group members:', error);
+            throw new common_1.ConflictException('Failed to get group members. Please try again.');
+        }
+    }
 };
 exports.WorkspaceGroupServiceService = WorkspaceGroupServiceService;
 exports.WorkspaceGroupServiceService = WorkspaceGroupServiceService = __decorate([
     (0, common_1.Injectable)(),
     __param(0, (0, typeorm_1.InjectRepository)(workspace_entity_1.Workspace)),
     __param(1, (0, typeorm_1.InjectRepository)(workspace_user_entity_1.WorkspaceMember)),
-    __metadata("design:paramtypes", [typeof (_a = typeof typeorm_2.Repository !== "undefined" && typeorm_2.Repository) === "function" ? _a : Object, typeof (_b = typeof typeorm_2.Repository !== "undefined" && typeorm_2.Repository) === "function" ? _b : Object])
+    __param(2, (0, typeorm_1.InjectRepository)(group_entity_1.Group)),
+    __param(3, (0, typeorm_1.InjectRepository)(group_member_entity_1.GroupMember)),
+    __param(4, (0, typeorm_1.InjectRepository)(chat_message_entity_1.ChatMessage)),
+    __metadata("design:paramtypes", [typeof (_a = typeof typeorm_2.Repository !== "undefined" && typeorm_2.Repository) === "function" ? _a : Object, typeof (_b = typeof typeorm_2.Repository !== "undefined" && typeorm_2.Repository) === "function" ? _b : Object, typeof (_c = typeof typeorm_2.Repository !== "undefined" && typeorm_2.Repository) === "function" ? _c : Object, typeof (_d = typeof typeorm_2.Repository !== "undefined" && typeorm_2.Repository) === "function" ? _d : Object, typeof (_e = typeof typeorm_2.Repository !== "undefined" && typeorm_2.Repository) === "function" ? _e : Object])
 ], WorkspaceGroupServiceService);
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/microservices": "^11.1.6",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/platform-socket.io": "^11.1.6",
         "@nestjs/typeorm": "^11.0.0",
+        "@nestjs/websockets": "^11.1.6",
         "@types/bcrypt": "^6.0.0",
         "bcrypt": "^6.0.0",
         "class-transformer": "^0.5.1",
@@ -27,6 +29,7 @@
         "pg": "^8.16.3",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "socket.io": "^4.8.1",
         "sqlite3": "^5.1.7",
         "typeorm": "^0.3.25",
         "uuid": "^11.1.0"
@@ -2474,6 +2477,24 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.6.tgz",
+      "integrity": "sha512-ozm+OKiRiFLNQdFLA3ULDuazgdVaPrdRdgtG/+404T7tcROXpbUuFL0eEmWJpG64CxMkBNwamclUSH6J0AeU7A==",
+      "dependencies": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.0.7",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.0.7.tgz",
@@ -2530,6 +2551,28 @@
         "reflect-metadata": "^0.1.13 || ^0.2.0",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
+      }
+    },
+    "node_modules/@nestjs/websockets": {
+      "version": "11.1.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.6.tgz",
+      "integrity": "sha512-jlBX5QpqhfEVfxkwxTesIjgl0bdhgFMoORQYzjRg1i+Z+Qouf4KmjNPv5DZE3DZRDg91E+3Bpn0VgW0Yfl94ng==",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-socket.io": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
       }
     },
     "node_modules/@noble/hashes": {
@@ -2695,6 +2738,11 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
@@ -2854,6 +2902,14 @@
       "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -4294,6 +4350,14 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/bcrypt": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
@@ -5462,6 +5526,88 @@
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -9119,6 +9265,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -10476,6 +10630,131 @@
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/socks": {
@@ -12429,6 +12708,26 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/microservices": "^11.1.6",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/platform-socket.io": "^11.1.6",
     "@nestjs/typeorm": "^11.0.0",
+    "@nestjs/websockets": "^11.1.6",
     "@types/bcrypt": "^6.0.0",
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
@@ -38,6 +40,7 @@
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "socket.io": "^4.8.1",
     "sqlite3": "^5.1.7",
     "typeorm": "^0.3.25",
     "uuid": "^11.1.0"

--- a/scripts/seed-chat-test-data.ts
+++ b/scripts/seed-chat-test-data.ts
@@ -1,0 +1,55 @@
+import { NestFactory } from '@nestjs/core';
+import { WorkspaceGroupServiceModule } from '../apps/workspace-group-service/src/workspace-group-service.module';
+import { WorkspaceGroupServiceService } from '../apps/workspace-group-service/src/workspace-group-service.service';
+
+async function seedTestData() {
+  const app = await NestFactory.createApplicationContext(WorkspaceGroupServiceModule);
+  const workspaceService = app.get(WorkspaceGroupServiceService);
+
+  try {
+    console.log('Creating test workspace...');
+    
+    // Create a test workspace
+    const workspace = await workspaceService.createWorkspace('test-user-1', {
+      workspacename: 'Test Chat Workspace',
+      description: 'Workspace for testing chat functionality'
+    });
+    
+    console.log('Workspace created:', workspace);
+
+    // Create a test group
+    const group = await workspaceService.createGroup('test-user-1', workspace.id, {
+      groupname: 'Test Chat Group',
+      description: 'Group for testing chat functionality'
+    });
+    
+    console.log('Group created:', group);
+
+    // Add a second user to test multi-user chat
+    await workspaceService.joinWorkspace('test-user-2', {
+      workspaceId: workspace.id
+    });
+    
+    console.log('Second user joined workspace');
+
+    // Add both users to the group
+    await workspaceService.joinLeaveGroup('test-user-2', {
+      groupId: group.id
+    });
+    
+    console.log('Second user joined group');
+
+    console.log('\n=== Test Data Created Successfully ===');
+    console.log(`Workspace ID: ${workspace.id}`);
+    console.log(`Group ID: ${group.id}`);
+    console.log('Test Users: test-user-1, test-user-2');
+    console.log('\nYou can now use these IDs to test the chat functionality!');
+    
+  } catch (error) {
+    console.error('Error creating test data:', error);
+  } finally {
+    await app.close();
+  }
+}
+
+seedTestData();


### PR DESCRIPTION
This pull request adds comprehensive group chat functionality to the API Gateway, including both REST and WebSocket support, and introduces new DTOs and endpoints for managing workspace groups. It also expands CORS configuration to support additional frontend hosts. The most important changes are grouped below:

**Group Chat Features**

* Added a new `ChatController` providing REST endpoints for chat history retrieval, sending messages, and fetching group members. (`apps/api-gateway/src/chat/chat.controller.ts`, [apps/api-gateway/src/chat/chat.controller.tsR1-R106](diffhunk://#diff-7f8df35930598698d12c3cd4f0ba5379a0d3debc1f7985061a041d74ff0ec748R1-R106))
* Introduced a `ChatGateway` WebSocket gateway supporting real-time group chat operations such as joining/leaving groups, sending messages, and retrieving chat history, with JWT authentication for socket connections. (`apps/api-gateway/src/chat/chat.gateway.ts`, [apps/api-gateway/src/chat/chat.gateway.tsR1-R250](diffhunk://#diff-f20ad59a59210efd7556e360f4d61badcd374445566014c7290452c350c48b6fR1-R250))
* Registered `ChatController`, `ChatGateway`, and `WsJwtAuthGuard` in the API Gateway module to enable chat features and WebSocket authentication. (`apps/api-gateway/src/api-gateway.module.ts`, [[1]](diffhunk://#diff-34a08dc019ec29ae9b93082220b9c40fd851e3ec1083b85a6061e4831bd82484R8-R12) [[2]](diffhunk://#diff-34a08dc019ec29ae9b93082220b9c40fd851e3ec1083b85a6061e4831bd82484L44-R48)

**Workspace Group Management**

* Added new DTOs for group and workspace operations, including creating groups, joining/leaving groups, and leaving workspaces. (`apps/api-gateway/src/workspace/dtos/workspace-gateway.dto.ts`, [apps/api-gateway/src/workspace/dtos/workspace-gateway.dto.tsR19-R50](diffhunk://#diff-7fc30920c5092611b4f0dfe25edb0ca5bc9c7d80a5adf62c03f88b7fcd5e62c5R19-R50))
* Extended `WorkspaceGatewayController` with endpoints for leaving a workspace, creating groups, retrieving groups, and joining/leaving groups, with robust error handling for each operation. (`apps/api-gateway/src/workspace/workspaceGateway.controller.ts`, [[1]](diffhunk://#diff-36f559a529de6306faadd67330073c890e4de6e80ab9fcb8c9bff5be803912fbL16-R16) [[2]](diffhunk://#diff-36f559a529de6306faadd67330073c890e4de6e80ab9fcb8c9bff5be803912fbR119-R167) [[3]](diffhunk://#diff-36f559a529de6306faadd67330073c890e4de6e80ab9fcb8c9bff5be803912fbR277-R419)

**Configuration**

* Updated CORS settings to allow requests from multiple local frontend hosts and support additional HTTP methods and headers. (`apps/api-gateway/src/main.ts`, [apps/api-gateway/src/main.tsL9-R12](diffhunk://#diff-62d9a32d244e80a9f344f3368d1f262f01682af4d772849e5a80290d5edf45dfL9-R12))- Updated package.json and package-lock.json to include:
  - @nestjs/platform-socket.io version 11.1.6
  - @nestjs/websockets version 11.1.6
  - socket.io version 4.8.1
- Added a new script to seed test chat data, creating a workspace and group for testing chat functionality.